### PR TITLE
Fix empty response body

### DIFF
--- a/jp/suzuri/SuzuriClient.as
+++ b/jp/suzuri/SuzuriClient.as
@@ -118,6 +118,7 @@
         }
 
         public function onResponseError(event:IOErrorEvent):void {
+            var urlLoader:URLLoader = event.target as URLLoader;
             var body:String = urlLoader.data;
             this.dispatchEvent(new SuzuriResponseEvent(500, event.text));
             this.lastStatusCode = null;


### PR DESCRIPTION
`HTTPStatusEvent.HTTP_RESPONSE_STATUS` イベントでは、レスポンスボディが取得できないようなので、`Event.COMPLETE` になってからtriggerするように変更
